### PR TITLE
Updates to grid view

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -100,7 +100,7 @@ days_to_process=()
 for f in $(revdir $rev)/*/delayspectrum_hpf*.h5
 do
     csd=$(basename $(dirname $f))
-    outfile=$(htmlfile $csd)
+    outfile=$(optdir $rev)/$(htmlfile $csd)
 
     if [[ ! -f "${outfile}" ]] || [[ "${outfile}" -ot "${f}" ]]
     then
@@ -116,7 +116,7 @@ do
     printf "[%4i of %i] processing CSD=%i \n" $i ${#days_to_process[@]} $csd
 
     printf "  Executing notebook.\n"
-    papermill ${daily_notebook} $(dnbfile $csd) -p LSD ${csd} -p rev_id 7 -k mlchime \
+    papermill ${daily_notebook} $(dnbfile $csd) -p LSD ${csd} -p rev_id 7 -k python3 \
         --report-mode --no-log-output --no-progress-bar
     printf "  Converting notebook to html.\n"
     jupyter nbconvert --to html --no-input --output-dir=$(optdir $rev) $(dnbfile $csd)
@@ -125,7 +125,7 @@ done
 
 # Update the 14-day notebook as well
 printf "Processing grid of recent days.\n"
-papermill ${weekly_notebook} $(wnbfile) -p rev_id ${rev} -k mlchime --report-mode \
+papermill ${weekly_notebook} $(wnbfile) -p rev_id ${rev} -k python3 --report-mode \
     --no-log-output --no-progress-bar
 printf " Converting notebook to html.\n"
 jupyter nbconvert --to html --no-input --output-dir=$(optdir $rev) $(wnbfile)

--- a/viewer/fetch_from_cedar.sh
+++ b/viewer/fetch_from_cedar.sh
@@ -7,7 +7,7 @@ SOURCEUSER=dvw
 SOURCEID=/root/.ssh/id_cedar_shared
 SOURCEHOST=cedar.computecanada.ca
 SOURCEDIR=/project/rpp-chime/chime/validation/rev_$REV
-SOURCEGLOB="rev${REV}_[0-9][0-9][0-9][0-9].html"
+SOURCEGLOB="rev${REV}_*.html"
 
 DESTBASE=/mnt/md1/daily
 DESTDIR=${DESTBASE}/rendered/

--- a/viewer/templates/fortnight.html.j2
+++ b/viewer/templates/fortnight.html.j2
@@ -3,7 +3,7 @@
 {% block ui %}
 <div class="logout">
 <button onclick="show_day('{{ csd }}')">daily view</button>
-<button onclick="daily_logout('{{ logout }}')">Logout</button>
+<button onclick="daily_logout('logout')">Logout</button>
 </div>
 {% endblock %}
 {% block iframesrc %}view?fetch=rev07_14days{% endblock %}

--- a/viewer/web/blurry.html
+++ b/viewer/web/blurry.html
@@ -1,1 +1,1 @@
-<HTML><BODY style="backgorund: white; margin: 0;"><IMG src="blurry.jpg"></BODY></HTML>
+<HTML><BODY style="background: white; margin: 0;"><IMG src="blurry.jpg"></BODY></HTML>

--- a/weekly_validation.ipynb
+++ b/weekly_validation.ipynb
@@ -19,24 +19,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "5780b4a4",
-   "metadata": {},
-   "source": [
-    "# Set up the revision and CSD range to view\n",
-    "**Pipeline Revision:** Integer daily pipeline revision to load\n",
-    "\n",
-    "**Range Days:** Integer number of days to load\n",
-    "\n",
-    "**CSD Start:** First CSD in the range. This can be provided in multiple ways:\n",
-    "- Integer CSD value: `CSD = 1900`\n",
-    "- Date: `CSD = \"yyyy/mm/dd\"`\n",
-    "- None: `CSD = None` -> displays the most recent `num_days`\n",
-    "\n",
-    "**View:** Choose to view the days in a grid or as a list. List view provide slightly more detail."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "id": "5f699e42",
@@ -53,7 +35,8 @@
     "# Number of days to show\n",
     "num_days = 14\n",
     "\n",
-    "# Set the start CSD\n",
+    "# Set the start CSD. This can be an integer or a string \"yyyy/mm/dd\".\n",
+    "# If `None`, the most recent days will be displayed\n",
     "CSD = None\n",
     "\n",
     "# Method to view the plots. Options are `list` or `grid`\n",


### PR DESCRIPTION
Some changes:
- Removes some markdown from the weekly notebook. This was used when prototyping, but it shouldn't really be there when rendering the notebooks. that info is just included in comments now
- Fixes a typo in `blurry.html`
- Change glob pattern in `fetch_from_cedar` to also sync the `14day` notebook (maybe this is too generic, but I'm not really sure if it's an issue)
- Fix `run.sh` to use a `chime` Jupyter kernel by default
- Fix the `fortnight` template to ensure the logout button works 