### PR TITLE
fix(viewer): Fix login in two-week mode

### DIFF
--- a/viewer/templates/base.html.j2
+++ b/viewer/templates/base.html.j2
@@ -2,12 +2,13 @@
 <HTML id="root">
   <HEAD>
     <META charset="utf-8" />
-    <LINK rel="stylesheet" type="text/css" href="/daily/daily.css" />
-    <SCRIPT type="text/javascript" src="/daily/daily.js"></SCRIPT>
-    <TITLE>CHIME daily viewer - {% block title %}BASE TITLE{% endblock %}</TITLE>{% block headmatter %}{% endblock %}
+    <LINK rel="stylesheet" type="text/css" href="{{ base_path }}/daily.css" />
+    <SCRIPT type="text/javascript" src="{{ base_path }}/daily.js"></SCRIPT>
+    <TITLE>CHIME daily viewer - {% block title %}BASE TITLE{% endblock %}</TITLE>
+    <script type="text/javascript">var script_name = "{{ script_name }}";</script>{% block headmatter %}{% endblock %}
   </HEAD>
   <BODY>
     <div class="ui {{ ui_class | d('') }}">{% if flash is defined %}<div id="flash" class="flash flash-{{ flash_type | d('info') }}">{{ flash }}{% else %}<div id="flash" class="flash flash-empty">&nbsp;{% endif %}</div>{% block ui %}BASE UI{% endblock %}</div>
-      <IFRAME class="ui {{ ui_class | d('') }}" id="frame" src="/daily/{% block iframesrc %}MISSING{% endblock %}"></IFRAME>
+      <IFRAME class="ui {{ ui_class | d('') }}" id="frame" src="{{ base_path }}/{% block iframesrc %}MISSING{% endblock %}"></IFRAME>
   </BODY>
 </HTML>

--- a/viewer/templates/fortnight.html.j2
+++ b/viewer/templates/fortnight.html.j2
@@ -3,7 +3,7 @@
 {% block ui %}
 <div class="logout">
 <button onclick="show_day('{{ csd }}')">daily view</button>
-<button onclick="daily_logout('logout')">Logout</button>
+<button onclick="fortnight_logout()">Logout</button>
 </div>
 {% endblock %}
 {% block iframesrc %}view?fetch=rev07_14days{% endblock %}

--- a/viewer/templates/login.html.j2
+++ b/viewer/templates/login.html.j2
@@ -1,7 +1,10 @@
 {% extends "base.html.j2" %}
 {% block title %}Login required{% endblock %}
 {% block ui %}<H2>Please Log In</H2>
-<form method="POST" action="/daily/view"><input type="hidden" name="csd" value="{{ csd }}"/>
+<form method="POST" action="{{ script_name }}"><input type="hidden" name="csd" value="{{ csd }}"/>
+{% if fortnight | d(false) %}
+<input type="hidden" name="fortnight" value="true"/>
+{% endif %}
 <label for="user_name" class="login">Username:</label> <input type="text" name="user_name"/>
 <br/>
 <label for="user_password" class="login">Password:</label> <input type="password" name="user_password"/>

--- a/viewer/web/daily.js
+++ b/viewer/web/daily.js
@@ -1,8 +1,10 @@
-function daily_logout(how) { location.assign('/daily/view?logout=' + how + '&csd=' + csd) }
+function daily_logout(how) { location.assign(script_name + '?logout=' + how + '&csd=' + csd) }
 
-function fortnight(how) { location.assign('/daily/view?fortnight=' + how + '&csd=' + csd) }
+function fortnight(how) { location.assign(script_name + '?fortnight=' + how + '&csd=' + csd) }
 
-function show_day(show_csd) { location.assign('/daily/view?csd=' + show_csd) }
+function fortnight_logout() { location.assign(script_name + '?logout=please&fortnight=yes') }
+
+function show_day(show_csd) { location.assign(script_name + '?csd=' + show_csd) }
 
 function set_disable(id, disable) {
   elem = document.getElementById(id)
@@ -29,13 +31,13 @@ function update_ui(opinion) {
 
   // Update the document
   document.title = "CHIME daily viewer - CSD " + csd
-  window.history.pushState(document.getElementById("root").innerHTML, "", "/daily/view?csd=" + csd)
+  window.history.pushState(document.getElementById("root").innerHTML, "", script_name + "?csd=" + csd)
 
   // Clear flash
   clear_flash()
 
   // Load new render
-  document.getElementById("frame").src = "/daily/view?fetch=rev07_" + csd
+  document.getElementById("frame").src = script_name + "?fetch=rev07_" + csd
 
   // Enable/disable buttons
   set_disable("button_first", csd == first_csd)
@@ -230,7 +232,7 @@ function submit_opinion() {
   })
 
   // POST data
-  xhr.open("POST", "/daily/view")
+  xhr.open("POST", script_name)
   xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
   xhr.send(post_data)
 }


### PR DESCRIPTION
Passes the 'fortnight' through the loging redirects.

Also, removed hard-coded references the URL path ("daily/view") so a test version can be easily deployed.