### PR TITLE
feat(viewer): Revision selection and back-end rewrite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 
 # Misc
 *.DS_Store
+.swp
+.*.swp
 
 # General files to ignore
 **/__pycache__

--- a/viewer/daily_viewer.py
+++ b/viewer/daily_viewer.py
@@ -24,14 +24,14 @@ from chimedb.dataflag import (
 # The version string used to look up the client record in the DB.
 _DB_VERSION = "v0.1"
 
-# Should eventually be a settable parameter
-_REVISION = 7
-
 # Session expiry time, in days.  May be fractional
 SESSION_EXPIRY_DAYS = 7
 
 # Header to invalidate the session cookie
 INVALIDATE_SESSION = ("Set-Cookie", "dv_session=; SameSite=Strict; Secure; Max-Age=0;")
+
+# Available pipeline revisions
+REVISIONS = list()
 
 # The DataFlagOpinionType and DataFlagClient we're using.  These are set on first use
 OPINION_TYPE = None
@@ -39,11 +39,7 @@ CLIENT = None
 
 # Directories
 template_dir = pathlib.Path(__file__).with_name("templates")
-web_dir = pathlib.Path(__file__).with_name("web")
 render_dir = pathlib.Path(__file__).with_name("rendered")
-
-# Our URL path
-script_name = ""
 
 # Set up Jinja2
 jinja_env = jinja2.Environment(
@@ -63,13 +59,29 @@ def set_globals():
             client_version=_DB_VERSION,
         )
 
+    # Find all available revisions
+    if not REVISIONS:
+        for datarev in DataRevision.select():
+            # DataRevision.name is of the form rev_##; find the integer part
+            try:
+                revision = int(datarev.name[4:])
+            except ValueError:
+                # Skip datarevs with unparsable names
+                continue
+
+            # Now look for stuff
+            for path in glob.iglob(f"rev{revision:02d}_????.html", root_dir=render_dir):
+                REVISIONS.append(revision)
+                break
+
+        if REVISIONS:
+            print(f"Available revisions: {REVISIONS!r}")
+        else:
+            raise RuntimeError(f"Nothing available in {render_dir}!")
+
 
 def render_template(name, data, headers=None):
     """Render a Jinja2 template `name` using `data`."""
-
-    # These are always part of the data
-    data["script_name"] = script_name
-    data["base_path"] = str(pathlib.Path(script_name).parent)
 
     template = jinja_env.get_template(name + ".html.j2")
     return 200, headers, "text/html; charset=utf-8", template.render(**data)
@@ -154,11 +166,32 @@ def check_login(query):
     )
 
 
+def strip_query(query):
+    """Strip dict `query` of all unnecessary keys.
+
+    Returns
+    -------
+    new_query: dict
+        A new dict is returns with only the keys
+        csd, rev, and fortnight (if present in `query`).
+    """
+    new_query = dict()
+
+    if "csd" in query and query["csd"]:
+        new_query["csd"] = query["csd"]
+    if "rev" in query and query["rev"]:
+        new_query["rev"] = query["rev"]
+    if "fortnight" in query:
+        new_query["fortnight"] = "yes"
+
+    return new_query
+
+
 def do_login(query):
     """Ask for, and perform login.
 
     On successful login, returns a tuple (True, user, cookie).
-    On failure returns a response providing the login page."""
+    On failure returns a WSGI response for the login page."""
 
     # We don't allow logging in via GET
     if query["_METHOD"] == "GET":
@@ -166,14 +199,12 @@ def do_login(query):
         query.pop("user_name", None)
         query.pop("user_password", None)
 
-    # Remember csd, if given
-    csd = query.get("csd", 0)
+    # Strip unimportant stuff from query
+    data = strip_query(query)
 
-    # Are we in two-week mode?
-    fortnight = "fortnight" in query
-
+    # Has the user already provided their credentials?
     if "user_name" in query and "user_password" in query:
-        # Try to log in.  `success`
+        # Try to log in.
         success, result = check_login(query)
 
         # Check for auth success.
@@ -181,16 +212,11 @@ def do_login(query):
             return success, *result
 
         # Otherwise, result is the flash text
-        flash = result
-        flash_type = "error"
+        data["flash"] = result
+        data["flash_type"] = "error"
     else:
-        flash = "Login required."
-        flash_type = "info"
-
-    # Data
-    data = {"csd": csd, "flash": flash, "flash_type": flash_type}
-    if fortnight:
-        data["fortnight"] = "yes"
+        data["flash"] = "Login required."
+        data["flash_type"] = "info"
 
     # Invalidate the cookie and show the login page
     return render_template(
@@ -265,15 +291,16 @@ def get_query(environ):
 
         query[key] = value
 
-    # Sanitise
-    try:
-        query["csd"] = int(query["csd"])
-    except KeyError:
-        # No CSD is fine
-        pass
-    except (TypeError, ValueError):
-        # Drop weird CSD values
-        del query["csd"]
+    # Sanitise some ints (which may be missing)
+    for key in ("csd", "ssd", "rev"):
+        try:
+            query[key] = int(query[key])
+        except KeyError:
+            # Missing key is fine
+            pass
+        except (TypeError, ValueError):
+            # Drop weird values
+            del query[key]
 
     # Append method
     query["_METHOD"] = method
@@ -281,114 +308,221 @@ def get_query(environ):
     return True, query
 
 
-def render_opinion_json(csds, counts):
-    """Convert the list returned by get_csds, into JSON."""
+def get_csds_for_rev(revision):
+    """Get a list of available CSDs for the specified pipeline revision.
+    The returned list is sorted descending."""
 
-    pre_json = list()
-
-    for day in reversed(sorted(csds.keys())):
-        if csds[day] is None:
-            pre_json.append(["none", "", 0, counts[day]])
-        else:
-            notes = "" if csds[day].notes is None else csds[day].notes
-            pre_json.append(
-                [csds[day].decision, notes, csds[day].last_edit, counts[day]]
-            )
-
-    return json.dumps(pre_json)
-
-
-def get_csds(user, revision):
-    """Get the list of available CSDs and the user's opinions, if any"""
-
-    # First get a list of available renders
-    csds = dict()
-    counts = {}
+    # Get a list of available renders
+    csds = list()
     for path in glob.iglob(f"rev{revision:02d}_????.html", root_dir=render_dir):
         try:
-            # None as a value here indicates no opinion for this user for this day
             id_ = int(path[-9:-5])
-            csds[id_] = None
-            # Record the total number of votes for this day as well
-            counts[id_] = 0
+            csds.append(id_)
         except ValueError:
             # Ignore non-numeric values
             pass
-    print(
-        f"daily_viewer: {len(csds)} pages in render_dir={render_dir}", file=sys.stderr
-    )
 
-    set_globals()
-    rev = DataRevision.get(name=f"rev_{_REVISION:02}")
-
-    # Now fetch opinions, if any, for this user:
-    query = DataFlagOpinion.select().where(
-        DataFlagOpinion.type == OPINION_TYPE,
-        DataFlagOpinion.revision == revision,
-        DataFlagOpinion.lsd << list(csds.keys()),
-    )
-
-    for opinion in query.execute():
-        counts[opinion.lsd] += 1
-        if opinion.user == user:
-            csds[opinion.lsd] = opinion
-
-    return csds, counts
+    return sorted(csds, reverse=True)
 
 
-def csd_vars(query, csds, opinion_counts):
-    """Determine which CSD to display on first load of the viewer.
+def get_revs_for_csd(csd):
+    """Get a list of available pipeline revisions for the specified CSD.
+    The returned list is sorted ascending."""
 
-    If one was specified in the request, that one will be used, if possible.
+    # Get a list of available renders
+    revs = list()
+    for path in glob.iglob(f"rev??_{csd:04d}.html", root_dir=render_dir):
+        try:
+            revs.append(int(path[3:5]))
+        except ValueError:
+            # Ignore non-numeric values
+            pass
 
-    After CSD selection, determine the values of the six selector buttons."""
+    return sorted(revs)
 
-    # A list of CSDs in descending order
-    csdlist = list(reversed(sorted(csds.keys())))
 
-    # This is the dict we will return
-    selections = {"csd_list": json.dumps(csdlist)}
+def get_opinions_for_csd(csd, revs, user):
+    """Fetch the user's current opinion of CSD `csd`.
 
-    # If there is no CSD specified in the request, then
-    # find the newest CSD with no opinion.  If that fails,
-    # select the newest CSD
-    if "csd" not in query or query["csd"] == 0:
-        for csd in csdlist:
-            if csds[csd] is None:
+    Parameters:
+    -----------
+    csd : int
+       The CSD to fetch opinions for; already vetted.
+    revs : list of ints
+        All revisions for which this CSD is valid
+    user : MediaWikiUser
+        The user's record
+
+    Returns:
+    -------
+    opinions : dict of dicts
+        A dict with keys for revision and values are
+        opinion dicts.  This is typically JSON serialised
+        and sent back to the client.
+    """
+
+    opinions = dict()
+    for rev in revs:
+        datarev = DataRevision.get(name=f"rev_{rev:02}")
+
+        # This is not specific to the user, but we shoe-horn it in anyways
+        opinion_count = (
+            DataFlagOpinion.select()
+            .where(
+                DataFlagOpinion.revision == datarev,
+                DataFlagOpinion.type == OPINION_TYPE,
+                DataFlagOpinion.lsd == csd,
+            )
+            .count()
+        )
+
+        # Get the opinion
+        try:
+            opinion = DataFlagOpinion.get(
+                DataFlagOpinion.revision == datarev,
+                DataFlagOpinion.type == OPINION_TYPE,
+                DataFlagOpinion.lsd == csd,
+                DataFlagOpinion.user == user,
+            )
+        except pw.DoesNotExist:
+            opinion = None
+
+        if opinion:
+            opinions[rev] = {
+                "csd": csd,
+                "decision": opinion.decision,
+                "last_edit": opinion.last_edit,
+                "notes": opinion.notes,
+                "count": opinion_count,
+            }
+        else:
+            opinions[rev] = {
+                "csd": csd,
+                "decision": "none",
+                "last_edit": 0,
+                "notes": "",
+                "count": opinion_count,
+            }
+
+    return opinions
+
+
+def csd_data(target, source, rev, user):
+    """Fetch data for the "current" CSD.
+
+    If a particular CSD (`target`) was specified in the request, that one will be used,
+    if possible.  Otherwise, this function tries to choose a suitable CSD.
+
+    Returns a dict of data for the chosen CSD, which is typically JSON-ified and sent
+    back to the client.
+
+    Parameters
+    ----------
+    target : int
+      The requested CSD, if any, or 0 if None was requested.
+    source : int
+      The "source" CSD: the CSD where the user was, when requesting a new CSD
+      or 0, if no source information is available.
+    rev : int
+      Integer pipeline revision, or 0 to use the default
+    user : MediaWikiUser
+      The user's record.
+
+    Returns
+    -------
+    data : dict
+        A dictionary of data relating to the chosen CSD.
+    """
+
+    # Set default revision, if necessary
+    if rev == 0:
+        rev = REVISIONS[0]
+
+    # Days available to the viewer.  Sorted in descending order
+    csdlist = get_csds_for_rev(rev)
+
+    if len(csdlist) == 0:
+        # If there are _no_ days in the chosen revision, fall back
+        # to the default revision
+        rev = REVISIONS[0]
+        csdlist = get_csds_for_rev(rev)
+
+        # Santiy check.  The default revision _must_ have data in it.
+        if len(csdlist) == 0:
+            raise RuntimeError(f"No CSDs found for default revision ({rev})!")
+
+    datarev = DataRevision.get(name=f"rev_{rev:02}")
+
+    # Subset of csdlist with opinions from this user (and this revision)
+    opinedcsds = {
+        opinion.lsd
+        for opinion in DataFlagOpinion.select(DataFlagOpinion.lsd).where(
+            DataFlagOpinion.revision == datarev,
+            DataFlagOpinion.type == OPINION_TYPE,
+            DataFlagOpinion.user == user,
+            DataFlagOpinion.lsd << csdlist,
+        )
+    }
+
+    # This is the dict we will return.  It probably shouldn't be
+    # called "selections" anymore.
+    selections = {"rev": rev, "first_csd": csdlist[-1], "last_csd": csdlist[0]}
+
+    # If there is no CSD provided, then find the newest CSD with no opinion.
+    # If that fails, select the newest CSD
+    if target == 0:
+        for target in csdlist:
+            if target not in opinedcsds:
                 break
         else:
             # Just use the last csd if we couldn't find one
-            csd = csdlist[0]
+            target = csdlist[0]
     else:
         # User specified a CSD
-        csd = query["csd"]
 
         # Set csd to the limits, if out of bounds
-        if csd > csdlist[0]:  # csdlist[0] is the largest CSD
-            csd = csdlist[0]
-        elif csd < csdlist[-1]:  # csdlist[-1] is the smallest CSD
-            csd = csdlist[-1]
+        if target > csdlist[0]:  # csdlist[0] is the largest CSD
+            target = csdlist[0]
+        elif target < csdlist[-1]:  # csdlist[-1] is the smallest CSD
+            target = csdlist[-1]
         else:
-            # csd is in range, but if it is not available,
+            # target is in range, but if it is not available,
             # go to the next day available
-            if csd not in csdlist:
-                for i in range(len(csdlist) - 1):
-                    if csd > csdlist[i + 1]:  # True when csd[i] > csd > csd[i + 1]
-                        csd = csdlist[i]
-                        break
+            if target not in csdlist:
+                # Figure out direction
+                if source == 0 or target > source:
+                    # Ascending mode
+                    for i in range(len(csdlist) - 1):
+                        if (
+                            target > csdlist[i + 1]
+                        ):  # True when csdlist[i] > target > csdlist[i + 1]
+                            target = csdlist[i]
+                            break
+                else:
+                    # Descending mode
+                    for i in reversed(range(len(csdlist) - 1)):
+                        if (
+                            target < csdlist[i]
+                        ):  # True when csdlist[i] > target > csdlist[i + 1]
+                            target = csdlist[i]
+                            break
+
+    # Index of target
+    index = csdlist.index(target)
 
     # Remember chosen CSD
-    selections["csd"] = csd
+    selections["csd"] = target
 
-    # Index of CSD
-    index = csdlist.index(csd)
+    # All revisions for this CSD
+    revs = get_revs_for_csd(target)
+    selections["revs"] = revs
 
-    # These are easy
-    selections["first_csd"] = csdlist[-1]
-    selections["last_csd"] = csdlist[0]
+    # Sanity check; there's probably a better way to handle this
+    if rev not in revs:
+        raise RuntimeError(f"render for rev {rev} CSD {target} disappeared!")
 
     # Determine Prev and PNO
-    if csd == csdlist[-1]:
+    if target == csdlist[-1]:
         # At the first CSD, so both are zero
         selections["prev_csd"] = 0
         selections["pno_csd"] = 0
@@ -397,7 +531,7 @@ def csd_vars(query, csds, opinion_counts):
 
         # Find a CSD with no opinion in the trailing part of the list:
         for pno in csdlist[index + 1 :]:
-            if csds[pno] is None:
+            if pno not in opinedcsds:
                 selections["pno_csd"] = pno
                 break
         else:
@@ -414,23 +548,16 @@ def csd_vars(query, csds, opinion_counts):
 
         # Find a CSD with no opinion in the leading part of the list:
         for nno in csdlist[index - 1 :: -1]:
-            if csds[nno] is None:
+            if nno not in opinedcsds:
                 selections["nno_csd"] = nno
                 break
         else:
             # None found
             selections["nno_csd"] = 0
 
-    # The current opinion for the selected CSD
-    if csds[csd] is None:
-        selections["csd_decision"] = "none"
-        selections["csd_notes"] = ""
-    else:
-        selections["csd_decision"] = csds[csd].decision
-        selections["csd_notes"] = "" if csds[csd].notes is None else csds[csd].notes
-
-    # Include the number of existing votes for this CSD
-    selections["opinion_count"] = opinion_counts[csd]
+    # Get the user's current opinion for the selected CSD, for all available revisions
+    # The opinions include the opinion count for _all_ users.
+    selections["opinions"] = get_opinions_for_csd(target, revs, user)
 
     return selections
 
@@ -463,18 +590,161 @@ def redirect_response(environ, headers, /, **query):
     return 302, headers
 
 
+def fetch_csd(user, query, extra_data=None):
+    """Return data for the fetch `query` to the client.
+
+    The data returned includes:
+        * a vetted (possibly changed) CSD and revision
+        * the targets of the navigation buttons
+        * the user's opinions for this CSD (for all revisions)
+
+    If `extra_data` is provided, it is merged into the generated
+    data, overriding any duplicate keys.
+
+    The data is JSON serialised and returned to the client.
+    """
+
+    # Tease out some data from the query
+    csd = int(query["fetch"])
+    ssd = int(query.get("ssd", 0))
+    rev = int(query.get("rev", REVISIONS[0]))
+
+    # Do the actual data fetch
+    data = csd_data(csd, ssd, rev, user)
+
+    # Add the client's request ID, if provided
+    if "request_id" in query:
+        data["request_id"] = query["request_id"]
+
+    # Any anything else
+    if extra_data:
+        data.update(extra_data)
+
+    # Return JSON in all cases
+    return 200, list(), "application/json", json.dumps(data)
+
+
+def known_csd(revision, csd):
+    """Is `csd` one we know about?
+
+    A "known" csd has a file in the rendered directory.
+    """
+
+    try:
+        return render_dir.joinpath(f"rev{revision:02d}_{csd:04d}.html").is_file()
+    except ValueError:
+        # Non-numeric csd or rev returns False
+        return False
+
+
+def delete_from_db(user, datarev, csd):
+    """Delete the opinion (user, rev, csd), if it exists
+
+    Also deletes categories.
+
+    Returns a dict with the resultant message flash.
+    """
+    try:
+        # Begin a transaction
+        with db.proxy.atomic():
+            # Get the current opinion ID, if any.
+            # The tuple (user, rev, type, lsd) is a unique key
+            opinion = DataFlagOpinion.get_or_none(
+                user=user,
+                revision=datarev,
+                type=OPINION_TYPE,
+                lsd=csd,
+            )
+            if opinion:
+                opinion.delete_instance()
+
+                return {"result": "good", "message": "Opinion Deleted"}
+            else:
+                return {"result": "good", "message": "No Change"}
+    except pw.OperationalError:
+        return {"result": "error", "message": "Error during DB Update!"}
+
+
+def update_db(user, datarev, csd, now, decision, notes):
+    """Update/add the given opinion.
+
+    Returns a dict with the resultant message flash.
+    """
+
+    result = {"csd": csd}
+
+    try:
+        # Begin a transaction
+        with db.proxy.atomic():
+            # Get the current opinion ID, if any.
+            # The tuple (user, datarev, type, lsd) is a unique key
+            opinion = DataFlagOpinion.get_or_none(
+                user=user,
+                revision=datarev,
+                type=OPINION_TYPE,
+                lsd=csd,
+            )
+
+            if opinion:
+                opinion.decision = decision
+                opinion.notes = notes
+                opinion.last_edit = now
+                opinion.client = CLIENT
+                opinion.save()
+
+                result["result"] = "good"
+                result["message"] = "Opinion Updated"
+            else:
+                # No update, so insert
+                opinion = DataFlagOpinion.create(
+                    type=OPINION_TYPE,
+                    user=user,
+                    decision=decision,
+                    creation_time=now,
+                    last_edit=now,
+                    client=CLIENT,
+                    revision=datarev,
+                    lsd=csd,
+                    notes=notes,
+                )
+                result["result"] = "good"
+                result["message"] = "Opinion Added"
+    except pw.OperationalError:
+        return {"result": "error", "message": "Error during DB Update!"}
+
+    return result
+
+
+# Error return for update_opinion
+def update_error(message):
+    # Even though there was an error, at the HTTP level,
+    # this is a scucess (=HTTP code 200)
+    return (
+        200,
+        list(),
+        "application/json",
+        json.dumps({"result": "error", "message": message}),
+    )
+
+
 def update_opinion(user, query):
     """Upsert an opinion in the database.
 
     Returns a JSON payload with the result of the DB update."""
 
-    set_globals()
-    rev = DataRevision.get(name=f"rev_{_REVISION:02}")
+    if "rev" not in query:
+        return update_error("Bad revision")
 
-    # Valid decisions
-    all_decisions = ["none", "bad", "unsure", "good"]
+    rev = query["rev"]
+    try:
+        datarev = DataRevision.get(name=f"rev_{rev:02}")
+    except pw.DoesNotExist:
+        return update_error("Bad revision")
 
+    # Vet decisions
     decision = query["decision"]
+    if decision not in ["none", "bad", "unsure", "good"]:
+        return update_error("Bad opinion")
 
     try:
         notes = query["notes"]
@@ -486,38 +756,22 @@ def update_opinion(user, query):
     # Convert CSD
     try:
         csd = int(query["csd"])
+        # Do we know about this CSD?
+        if not known_csd(rev, csd):
+            csd = 0
     except (KeyError, TypeError):
         csd = 0
+
+    # Validate required fields
+    if csd <= 0:
+        return update_error("Bad CSD")
 
     # This will get JSON-ified
     result = dict(csd=csd, decision=decision)
 
-    # Validate required fields
-    if csd <= 0:
-        result["result"] = "error"
-        result["message"] = "Bad CSD"
-    elif decision not in all_decisions:
-        result["result"] = "error"
-        result["message"] = "Bad Opinion"
-    elif decision == "none":
-        # This is a request to delete an opinion.
-        #
-        # The tuple (user, rev, type, lsd) is a unique key, so there can only
-        # ever be at most one record deleted, but we put a limit on, just in case
-        query = (
-            DataFlagOpinion.delete()
-            .where(
-                DataFlagOpinion.user == user,
-                DataFlagOpinion.revision == rev,
-                DataFlagOpinion.type == OPINION_TYPE,
-                DataFlagOpinion.lsd == csd,
-            )
-            .limit(1)
-        )
-        print(query.sql(), file=sys.stderr)
-        query.execute()
-        result["result"] = "good"
-        result["message"] = "Opinion Deleted"
+    if decision == "none":
+        # A request to delete an opinion (if it exists).
+        result.update(delete_from_db(user, rev, csd))
     else:
         # A request to update or insert an opinion.
         now = time.time()
@@ -527,52 +781,20 @@ def update_opinion(user, query):
         else:
             result["notes"] = ""
 
-        query = (
-            DataFlagOpinion.update(
-                decision=decision, notes=notes, last_edit=now, client=CLIENT
-            )
-            .where(
-                DataFlagOpinion.user == user,
-                DataFlagOpinion.revision == rev,
-                DataFlagOpinion.type == OPINION_TYPE,
-                DataFlagOpinion.lsd == csd,
-            )
-            .limit(1)
-        )
-        print(query.sql(), file=sys.stderr)
-        count = query.execute()
-        if count == 0:
-            # No update, so insert
-            query = DataFlagOpinion.insert(
-                type=OPINION_TYPE,
-                user=user,
-                decision=decision,
-                creation_time=now,
-                last_edit=now,
-                client=CLIENT,
-                revision=rev,
-                lsd=csd,
-                notes=notes,
-            )
-            print(query.sql(), file=sys.stderr)
-            query.execute()
-            result["result"] = "good"
-            result["message"] = "Opinion Added"
-        else:
-            result["result"] = "good"
-            result["message"] = "Opinion Updated"
+        result.update(update_db(user, rev, csd, now, decision, notes))
 
-    result["opinion_count"] = (
-        DataFlagOpinion.select()
-        .where(
-            DataFlagOpinion.revision == rev,
-            DataFlagOpinion.type == OPINION_TYPE,
-            DataFlagOpinion.lsd == csd,
-        )
-        .count()
-    )
+    # On error, just return the error
+    if result["result"] == "error":
+        return update_error(result["message"])
 
-    # Done, return JSON in all cases
+    # otherwise, re-fetch the opinion from the DB and return it to the client
+    result.update(csd_data(csd, 0, rev, user))
+
+    # Add the client's request ID, if provided
+    if "request_id" in query:
+        result["request_id"] = query["request_id"]
+
+    # Return JSON in all cases
     return 200, list(), "application/json", json.dumps(result)
 
 
@@ -592,7 +814,6 @@ def get_response(environ):
     """
 
     headers = list()
-    data = dict()
 
     # Vet the request
     result, query = get_query(environ)
@@ -604,19 +825,8 @@ def get_response(environ):
         # Logout
         headers.append(INVALIDATE_SESSION)
 
-        # New query for the redirect
-        new_query = dict()
-        if "csd" in query and query["csd"]:
-            new_query["csd"] = query["csd"]
-        if "fortnight" in query:
-            new_query["fortnight"] = "yes"
-
-        # Redirect back to self, maybe with a CSD
-        return redirect_response(environ, headers, **new_query)
-
-    # Script name
-    global script_name
-    script_name = environ.get("SCRIPT_NAME")
+        # Redirect back to self, maybe with a pointer to where we were
+        return redirect_response(environ, headers, **strip_query(query))
 
     # Connect to DB
     db.connect(read_write=True)
@@ -624,9 +834,9 @@ def get_response(environ):
     # Check for login
     user = get_user(environ)
     if not user:
-        # If this is a fetch or opinion push, just return 403 and invalidate
+        # If this is a fetch, render or decision push, just return 403 and invalidate
         # the session
-        if "fetch" in query or "decision" in query:
+        if "fetch" in query or "render" in query or "decision" in query:
             return 403, [INVALIDATE_SESSION]
 
         # Returns (True, user) on successful login, or the 4-tuple response
@@ -635,6 +845,7 @@ def get_response(environ):
 
         # Check for login success
         if result[0] is not True:
+            # As pointed out above, in this case `result` is a full 4-tuple response.
             return result
 
         # Otherwise, result[1] is the user
@@ -643,19 +854,15 @@ def get_response(environ):
         # result[2] is the set-cookie header
         headers.append(result[2])
 
-        # New query for the redirect
-        new_query = dict()
-        if "csd" in query and query["csd"]:
-            new_query["csd"] = query["csd"]
-        if "fortnight" in query:
-            new_query["fortnight"] = "yes"
-
         # Perform a redirect to cleanse the request of login details.
         # This also allows us to verify that the client has correctly set
         # the session cookie
-        return redirect_response(environ, headers, **new_query)
+        return redirect_response(environ, headers, **strip_query(query))
 
     # If we get here, we're logged in, and both user and query are valid.
+    set_globals()
+
+    # What kind of query is this?
     if "fortnight" in query:
         # Render the 2-week view
         return render_template(
@@ -663,27 +870,43 @@ def get_response(environ):
             data={"csd": query.get("csd", 0), "ui_class": "ui_2week"},
             headers=headers,
         )
-    if "fetch" in query:
+    if "render" in query:
+        # A request for a rendered notebook
+        if "/" in query["render"]:
+            # Path elements aren't allowed in the render request
+            return 403, headers
+
         # Returns an HTML file from the render_dir
         try:
-            with open(render_dir.joinpath(f"{query['fetch']}.html"), "rb") as f:
+            with open(render_dir.joinpath(f"{query['render']}.html"), "rb") as f:
                 return 200, headers, "text/html; charset=utf-8", [f.read()]
         except (FileNotFoundError, PermissionError):
             return 404, headers
-    elif "decision" in query:
+    if "fetch" in query:
+        # A CSD data fetch
+        return fetch_csd(user, query)
+    if "decision" in query:
         # An opinion update
         return update_opinion(user, query)
 
-    # Available days with opinions (if any)
-    csds, opinion_counts = get_csds(user, _REVISION)
-    data["opinions"] = render_opinion_json(csds, opinion_counts)
+    # Otherwise, this is just a simple GET for a viewer page.
+
+    # Template data
+    data = {
+        "revisions": REVISIONS,
+        "logout": random.choice(
+            ["yes", "ok", "okay", "now", "please", "do_it", "logout"]
+        ),
+    }
 
     # Choose the first CSD to display on page load
-    data.update(csd_vars(query, csds, opinion_counts))
-
-    # Logout
-    data["logout"] = random.choice(
-        ["yes", "ok", "okay", "now", "please", "do_it", "logout"]
+    data.update(
+        csd_data(
+            query.get("csd", 0),
+            query.get("ssd", 0),
+            query.get("rev", 0),
+            user,
+        )
     )
 
     # Render the view

--- a/viewer/templates/base.html.j2
+++ b/viewer/templates/base.html.j2
@@ -2,13 +2,13 @@
 <HTML id="root">
   <HEAD>
     <META charset="utf-8">
-    <LINK rel="stylesheet" type="text/css" href="{{ base_path }}/daily.css">
-    <SCRIPT type="text/javascript" src="{{ base_path }}/daily.js"></SCRIPT>
+    <LINK rel="stylesheet" type="text/css" href="daily.css">
+    <SCRIPT type="text/javascript" src="daily.js"></SCRIPT>
     <TITLE>CHIME daily viewer - {% block title %}BASE TITLE{% endblock %}</TITLE>
-    <script type="text/javascript">var script_name = "{{ script_name }}";</script>{% block headmatter %}{% endblock %}
+    {% block headmatter %}{% endblock %}
   </HEAD>
   <BODY>
     <div class="ui {{ ui_class | d('') }}">{% if flash is defined %}<div id="flash" class="flash flash-{{ flash_type | d('info') }}">{{ flash }}{% else %}<div id="flash" class="flash flash-empty">&nbsp;{% endif %}</div>{% block ui %}BASE UI{% endblock %}</div>
-      <IFRAME class="ui {{ ui_class | d('') }}" id="frame" src="{{ base_path }}/{% block iframesrc %}MISSING{% endblock %}"></IFRAME>
+      <IFRAME class="ui {{ ui_class | d('') }}" id="frame" src="{% block iframesrc %}MISSING{% endblock %}"></IFRAME>
   </BODY>
 </HTML>

--- a/viewer/templates/fortnight.html.j2
+++ b/viewer/templates/fortnight.html.j2
@@ -6,4 +6,4 @@
 <button onclick="fortnight_logout()">Logout</button>
 </div>
 {% endblock %}
-{% block iframesrc %}view?fetch=rev07_14days{% endblock %}
+{% block iframesrc %}view?render=rev07_14days{% endblock %}

--- a/viewer/templates/view.html.j2
+++ b/viewer/templates/view.html.j2
@@ -1,6 +1,8 @@
 {% extends "base.html.j2" %}
-{% block title %}CSD {{ csd }}{% endblock %}
+{% block title %}CSD {{ csd }}, revision {{ rev }}{% endblock %}
 {% block headmatter %}<script type="text/javascript">
+var rev = {{ rev }};
+var revisions = {{ revisions }};
 var csd = {{ csd }};
 var first_csd = {{ first_csd }};
 var pno_csd = {{ pno_csd }};
@@ -8,7 +10,6 @@ var prev_csd = {{ prev_csd }};
 var next_csd = {{ next_csd }};
 var nno_csd = {{ nno_csd }};
 var last_csd = {{ last_csd }};
-var csd_list = {{ csd_list }};
 var opinions = {{ opinions }};
 </script>
 {% endblock %}
@@ -23,24 +24,29 @@ var opinions = {{ opinions }};
 <button id="button_first" title="First CSD" onclick="set_csd(first_csd)"{% if csd == first_csd %} disabled{% endif %}><svg viewBox="0 0 24 24"><path d="M2 0 V24 H6 V12 L14 24 H22 L14 12 L22 0 H14 L6 12 V0 Z "/></svg></button>
 <button id="button_pno" title="Previous CSD with no opinion" onclick="set_csd(pno_csd)"{% if pno_csd == 0 %} disabled{% endif %}><svg viewBox="0 0 24 24"><path d="M6 0 L0 12 L6 24 H14 L8 12 L14 0 Z M16 0 L10 12 L16 24 H24 L18 12 L24 0 Z"/></svg></button>
 <button id="button_prev" title="Previous CSD" onclick="set_csd(prev_csd)"{% if prev_csd == 0 %} disabled{% endif %}><svg viewBox="0 0 24 24"><path d="M10 0 L4 12 L10 24 H18 L12 12 L18 0 Z"/></svg></button>
-<input id="CSD" type="text" value="{{ csd }}" onchange="vet_csd()"></ul>
+<input id="CSD" type="text" value="{{ csd }}" onchange="set_csd(document.getElementById('CSD').value)"></ul>
 <button id="button_next" title="Next CSD" onclick="set_csd(next_csd)"{% if next_csd == 0 %} disabled{% endif %}><svg viewBox="0 0 24 24"><path d="M14 0 L20 12 L14 24 H6 L12 12 L6 0 Z"/></svg></button>
 <button id="button_nno" title="Next CSD with no opinion" onclick="set_csd(nno_csd)"{% if nno_csd == 0 %} disabled{% endif %}><svg viewBox="0 0 24 24"><path d="M18 0 L24 12 L18 24 H10 L16 12 L10 0 Z M8 0 L14 12 L8 24 H0 L6 12 L0 0 Z"/></svg></button>
 <button id="button_last" title="Last CSD" onclick="set_csd(last_csd)"{% if csd == last_csd %} disabled{% endif %}><svg viewBox="0 0 24 24"><path d="M22 0 V24 H18 V12 L10 24 H2 L10 12 L2 0 H10 L18 12 V0 Z "/></svg></button>
 </div>
+<br><span class="pickrev-span">Revision:</span>
+{%- for pickrev in revisions %}
+<button class="pickrev{% if pickrev == rev %} pickrev-selected{%- endif %} {% if pickrev in opinions
+%}pickrev-{{ opinions[pickrev].decision | d("missing") }}"{% else %}pickrev-missing" disabled{% endif %} id="pickrev-{{ pickrev }}" onclick="set_rev({{ pickrev }})">{{ pickrev }}</button>
+{% endfor %}
 </div>
 <div class="vote">
-<H2 id="opinion-h2">Opinion for CSD #{{ csd }}</H2>
+<H2 id="opinion-h2">Opinion for CSD #{{ csd }}, rev {{rev}}</H2>
 <button type="Submit" onclick="submit_opinion()">Submit</button>
-<span id="opinion-count">{{ opinion_count }} existing votes</span>
+<span id="opinion-count">{{ opinions[rev].count }} existing votes</span>
 <div class="opinion-select">
-<input type="radio" id="opinion-none" name="opinion" onclick="set_disable('opinion-notes', true)" value="none"{% if csd_decision == "none" %} checked{% endif %}><label for="opinion-none">None</label>
-<input type="radio" id="opinion-bad" name="opinion" onclick="set_disable('opinion-notes', false)" value="bad"{% if csd_decision == "bad" %} checked{% endif %}><label for="opinion-bad">Bad</label>
-<input type="radio" id="opinion-unsure" name="opinion" onclick="set_disable('opinion-notes', false)" value="unsure"{% if csd_decision == "unsure" %} checked{% endif %}><label for="opinion-unsure">Unsure</label>
-<input type="radio" id="opinion-good" name="opinion" onclick="set_disable('opinion-notes', false)" value="good"{% if csd_decision == "good" %} checked{% endif %}><label for="opinion-good">Good</label>
+<input type="radio" id="opinion-none" name="opinion" onclick="set_disable('opinion-notes', true)" value="none"{% if opinions[rev].decision == "none" %} checked{% endif %}><label for="opinion-none">None</label>
+<input type="radio" id="opinion-bad" name="opinion" onclick="set_disable('opinion-notes', false)" value="bad"{% if opinions[rev].decision == "bad" %} checked{% endif %}><label for="opinion-bad">Bad</label>
+<input type="radio" id="opinion-unsure" name="opinion" onclick="set_disable('opinion-notes', false)" value="unsure"{% if opinions[rev].decision == "unsure" %} checked{% endif %}><label for="opinion-unsure">Unsure</label>
+<input type="radio" id="opinion-good" name="opinion" onclick="set_disable('opinion-notes', false)" value="good"{% if opinions[rev].decision == "good" %} checked{% endif %}><label for="opinion-good">Good</label>
 </div>
 <label for="opinion-notes">Notes:</label><br/>
-<textarea id="opinion-notes" name="notes" rows="6" cols="80" placeholder="Opinion notes"{% if csd_decision == "none" %} disabled{% endif %}>{{ csd_notes | d("") }}</textarea>
+<textarea id="opinion-notes" name="notes" rows="6" cols="80" placeholder="Opinion notes"{% if opinions[rev].decision == "none" %} disabled{% endif %}>{{ opinions[rev].notes | d("") }}</textarea>
 </div>
 {% endblock %}
-{% block iframesrc %}view?fetch=rev07_{{ csd }}{% endblock %}
+{% block iframesrc %}view?render=rev{{ "%02d" % rev }}_{{ csd }}{% endblock %}

--- a/viewer/web/daily.css
+++ b/viewer/web/daily.css
@@ -103,6 +103,10 @@ span.pickrev-span {
   font-size: x-large;
 }
 
+button.pickrev {
+  -webkit-appearance: none;
+}
+
 button.pickrev-good {
   background: green;
 }
@@ -117,5 +121,5 @@ button.pickrev-bad {
 }
 
 button.pickrev-selected {
-  border: 2px solid blue;
+  border-style: inset;
 }

--- a/viewer/web/daily.css
+++ b/viewer/web/daily.css
@@ -98,3 +98,24 @@ div.csd-selector > input {
   font-size: x-large;
   padding: 0;
 }
+
+span.pickrev-span {
+  font-size: x-large;
+}
+
+button.pickrev-good {
+  background: green;
+}
+
+button.pickrev-unsure {
+  background: yellow;
+}
+
+button.pickrev-bad {
+  background: red;
+  border: none;
+}
+
+button.pickrev-selected {
+  border: 2px solid blue;
+}


### PR DESCRIPTION
This is a fairly extensive re-write with the following goals:
* make pipeline revision both dynamic and selectable
* remove the front-loading of _all_ a user's opinions on first log-in

Additionally, there's been a bit of tidying up

## Removing front-loading

Closes #19 

As first written, the viewer used to find all opinions for a user when they first logged in.  This data was shoved into the rendered HTML template (in a very non-JSON-y way, for unknown reasons).  The only benefit of doing this was that the client never had to contact the server again (except if the user wanted to update their opinion).

Fine in theory, if there are only a few opinions for a user (which was true when the viewer was first written), but causes more-and-more slowdown as opinions accumulate over time.

In place of this, the client now side-loads opinions for a CSD (for all available revisions) by sending a `fetch` request to the server, which returns the data in JSON (see `fetch_csd` in the server, though most of the work is done in `csd_data`; and also `set_csd` in the client).

The downside here is there is a delay when switching CSDs in the viewer as the viewer has to wait for the server to return the data, but I don't find this delay noticable in practice.

Specific server-side changes:
* NB: the "fetch" query parameter was previously used when the client asked for a rendered notebook page.  That key has been renamed to "render".  The "fetch" parameter is now used for a CSD data side-load request
* The `fetch_csd` function is used to respond to these side-loading requests.  Most of the actual data generation is implemented in `csd_data` (which evolved from the `csd_vars` function and is also used after an opinion update to generate the data returned to the client).

Specific client-side changes:
* The `csd_list` global has been deleted (formerly a list of all available CSDs)
* The `opinions` global now holds the user's opinion for the current CSD only (indexed by revision), rather than all CSDs.
* The `vet_csd` function, which was used to validate numbers typed into the CSD box, has been deleted (the functionality is now handled by the server during the side-loading)

## Pipeline revision selection

Closes #20

The fixed global `_REVISION` has been removed.  In its place, the viewer now will dynamically figure out which revisions to load/display:

* On first load (i.e. when a worker first serves a page and loads its globals, the server walks through `DataRevision` and finds all revisions for which at least one rendered notebook exists.  This ends up as the `REVISIONS` global, and will remain fixed until server restart.
* Due to the side-loading, whenever data from a new CSD is requested, the server will find all rendered notebooks for that CSD and provide the data to the client.
* In the client there are now buttons to switch between revisions.  The list of buttons is fixed by the contents of `REVISIONS` (i.e. it doesn't change unless a server restart happens) but, if the currently-viewed CSD has no rendered notebook for a particular revision, the corresponding revision button is disabled to indicate that.
* Otherwise, revision buttons are coloured to indicate the user's submitted opinion for that day (if any).
* Because a CSD-fetch side-load returns all revisions, switching between revisions for a CSD does not cause another server hit.

Specific changes:
* revision number (`rev` parameter) must be submitted with all requests now, and is provided in all responses.  When not given a valid revision number, the server will default to the lowest available revision.  Instances where a client's query data was stripped of "unimportant" data has now been unified into the `strip_query` function.
* The `update_ui` client function has been broken up into two parts: `update_data` which updates the globals based on a server's response, and `draw_ui` which performs the document update based on the state of the globals.  `update_data` is called by side-loader callbacks, and in turn will call `draw_ui`, but the `draw_ui` function is also called by the revision selection buttons (via their `set_rev` function), which doesn't involve a side-load.

## Other changes

I've removed the `script_name` and `base_path` vars which were an unnecessary attempt to tell the client where to send requests: the client doesn't need this; it already knows the URL it's using.  More evidence that these are not needed: they were broken when we transitioned the viewer to gunicorn (both ended up as `""`) but the client didn't notice or care).

This PR breaks up the `update_opinion` function in the server, which isn't technically necessary, and only done in anticipation of the category handling stuff.