### PR TITLE
Fix REV interpreted as octal

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -116,7 +116,7 @@ do
     printf "[%4i of %i] processing CSD=%i \n" $i ${#days_to_process[@]} $csd
 
     printf "  Executing notebook.\n"
-    papermill ${daily_notebook} $(dnbfile $csd) -p LSD ${csd} -p rev_id 7 -k python3 \
+    papermill ${daily_notebook} $(dnbfile $csd) -p LSD ${csd} -p rev_id ${rev} -k python3 \
         --report-mode --no-log-output --no-progress-bar
     printf "  Converting notebook to html.\n"
     jupyter nbconvert --to html --no-input --output-dir=$(optdir $rev) $(dnbfile $csd)

--- a/run.sh
+++ b/run.sh
@@ -27,11 +27,11 @@ usage() {
 }
 
 revdir () {
-    printf "${base}/rev_%02i" $1
+    printf "${base}/rev_${1}"
 }
 
 optdir () {
-    printf "${outputdir}/rev_%02i" $1
+    printf "${outputdir}/rev_${1}"
 }
 
 htmlfile () {
@@ -86,11 +86,11 @@ then
 fi
 
 # Resolve the latest revision if needed
-if [[ "$rev" == "latest" ]]
+if [[ "${rev}" == "latest" ]]
 then
     echo $base
     rev=$(ls $base | grep rev | sort | tail -n 1 | cut -c 5-)
-    printf "Using latest revision rev_%02i\n" $rev
+    printf "Using latest revision rev_${rev}\n"
 fi
 
 echo "Scanning ${base} for rev_${rev} days to process..."

--- a/run.sh
+++ b/run.sh
@@ -43,7 +43,7 @@ dnbfile () {
 }
 
 wnbfile () {
-    echo "${workingdir}/rev${rev}_14days.ipynb"
+    echo "${workingdir}/14dayview.ipynb"
 }
 
 rev="latest"

--- a/viewer/templates/fortnight.html.j2
+++ b/viewer/templates/fortnight.html.j2
@@ -6,4 +6,4 @@
 <button onclick="fortnight_logout()">Logout</button>
 </div>
 {% endblock %}
-{% block iframesrc %}view?render=rev07_14days{% endblock %}
+{% block iframesrc %}view?fetch=14dayview{% endblock %}


### PR DESCRIPTION
In some spots, this script would interpret the `REV` variable as an octal. This wasn't an issue earlier, but with `REV=08` it is.