### PR TITLE
fix(viewer): Fix URL of 14-day view iframe

### DIFF
--- a/viewer/templates/fortnight.html.j2
+++ b/viewer/templates/fortnight.html.j2
@@ -6,4 +6,4 @@
 <button onclick="fortnight_logout()">Logout</button>
 </div>
 {% endblock %}
-{% block iframesrc %}view?fetch=14dayview{% endblock %}
+{% block iframesrc %}view?render=14dayview{% endblock %}


### PR DESCRIPTION
I apparently broke this in #25 by neglecting to update this template (i.e. this isn't related to the page rename).