### PR TITLE
fix(viewer): Fix passing "rev" through redirects

### DIFF
--- a/viewer/daily_viewer.py
+++ b/viewer/daily_viewer.py
@@ -867,7 +867,11 @@ def get_response(environ):
         # Render the 2-week view
         return render_template(
             "fortnight",
-            data={"csd": query.get("csd", 0), "ui_class": "ui_2week"},
+            data={
+                "csd": query.get("csd", 0),
+                "rev": query.get("rev", 0),
+                "ui_class": "ui_2week",
+            },
             headers=headers,
         )
     if "render" in query:

--- a/viewer/deploy_to_venv
+++ b/viewer/deploy_to_venv
@@ -16,7 +16,7 @@
 # see the ./test_server script, instead.
 
 # Things to deploy.  Directories are deployed recursively
-DEPLOY_LIST="daily_viewer.py fetch_from_cedar.sh templates web"
+DEPLOY_LIST="daily_viewer.py templates web"
 
 function check_venv () {
   if [[ "x${VIRTUAL_ENV}" = "x" ]]; then

--- a/viewer/templates/fortnight.html.j2
+++ b/viewer/templates/fortnight.html.j2
@@ -1,9 +1,13 @@
 {% extends "base.html.j2" %}
 {% block title %}2-week view{% endblock %}
+{% block headmatter %}<script type="text/javascript">
+var rev = {{ rev | d(0) }};
+var csd = {{ csd | d(0) }};
+</script>{% endblock %}
 {% block ui %}
 <div class="logout">
-<button onclick="show_day('{{ csd }}')">daily view</button>
-<button onclick="fortnight_logout()">Logout</button>
+<button onclick="show_day()">daily view</button>
+<button onclick="daily_logout('yes')">Logout</button>
 </div>
 {% endblock %}
 {% block iframesrc %}view?render=14dayview{% endblock %}

--- a/viewer/templates/login.html.j2
+++ b/viewer/templates/login.html.j2
@@ -1,7 +1,7 @@
 {% extends "base.html.j2" %}
 {% block title %}Login required{% endblock %}
 {% block ui %}<H2>Please Log In</H2>
-<form method="POST" action="{{ script_name }}"><input type="hidden" name="csd" value="{{ csd }}">
+<form method="POST" action="{{ script_name }}"><input type="hidden" name="csd" value="{{ csd | d(0) }}"><input type="hidden" name="rev" value="{{ rev | d(0) }}">
 {% if fortnight | d(false) %}
 <input type="hidden" name="fortnight" value="true">
 {% endif %}

--- a/viewer/web/daily.js
+++ b/viewer/web/daily.js
@@ -1,13 +1,11 @@
 // This is used to track asynchrous fetch requests.
 var request_id = 0;
 
-function daily_logout(how) { location.assign(window.location.pathname + '?logout=' + how + '&csd=' + csd) }
+function daily_logout(how) { location.assign(window.location.pathname + '?logout=' + how + '&csd=' + csd + '&rev=' + rev) }
 
-function fortnight(how) { location.assign(window.location.pathname + '?fortnight=' + how + '&csd=' + csd) }
+function fortnight(how) { location.assign(window.location.pathname + '?fortnight=' + how + '&csd=' + csd + '&rev=' + rev) }
 
-function fortnight_logout() { location.assign(window.location.pathname + '?logout=please&fortnight=yes') }
-
-function show_day(show_csd) { location.assign(window.location.pathname + '?csd=' + show_csd) }
+function show_day() { location.assign(window.location.pathname + '?csd=' + csd + '&rev=' + rev) }
 
 // returns a string of the form "rev07"
 function revname(rev) {


### PR DESCRIPTION
The user's chosen revision was getting forgotten in a lot of places where there's a server-side 302 redirect (to/from 14-day view, login/lougout) due to the "rev" parameter not being properly forwarded.

Has been deployed.