### PR TITLE
Fix CSD nav buttons:

### DIFF
--- a/viewer/templates/view.html.j2
+++ b/viewer/templates/view.html.j2
@@ -5,10 +5,8 @@ var rev = {{ rev }};
 var revisions = {{ revisions }};
 var csd = {{ csd }};
 var first_csd = {{ first_csd }};
-var pno_csd = {{ pno_csd }};
 var prev_csd = {{ prev_csd }};
 var next_csd = {{ next_csd }};
-var nno_csd = {{ nno_csd }};
 var last_csd = {{ last_csd }};
 var opinions = {{ opinions }};
 </script>
@@ -22,11 +20,11 @@ var opinions = {{ opinions }};
 <H2>Choose CSD:</H2>
 <div class="csd-selector">
 <button id="button_first" title="First CSD" onclick="set_csd(first_csd)"{% if csd == first_csd %} disabled{% endif %}><svg viewBox="0 0 24 24"><path d="M2 0 V24 H6 V12 L14 24 H22 L14 12 L22 0 H14 L6 12 V0 Z "/></svg></button>
-<button id="button_pno" title="Previous CSD with no opinion" onclick="set_csd(pno_csd)"{% if pno_csd == 0 %} disabled{% endif %}><svg viewBox="0 0 24 24"><path d="M6 0 L0 12 L6 24 H14 L8 12 L14 0 Z M16 0 L10 12 L16 24 H24 L18 12 L24 0 Z"/></svg></button>
+<button id="button_pno" title="Previous CSD with no opinion" onclick="set_csd('pno')"{% if csd == first_csd %} disabled{% endif %}><svg viewBox="0 0 24 24"><path d="M6 0 L0 12 L6 24 H14 L8 12 L14 0 Z M16 0 L10 12 L16 24 H24 L18 12 L24 0 Z"/></svg></button>
 <button id="button_prev" title="Previous CSD" onclick="set_csd(prev_csd)"{% if prev_csd == 0 %} disabled{% endif %}><svg viewBox="0 0 24 24"><path d="M10 0 L4 12 L10 24 H18 L12 12 L18 0 Z"/></svg></button>
-<input id="CSD" type="text" value="{{ csd }}" onchange="set_csd(document.getElementById('CSD').value)"></ul>
+<input id="CSD" type="text" value="{{ csd }}" onchange="set_csd(+document.getElementById('CSD').value)"></ul>
 <button id="button_next" title="Next CSD" onclick="set_csd(next_csd)"{% if next_csd == 0 %} disabled{% endif %}><svg viewBox="0 0 24 24"><path d="M14 0 L20 12 L14 24 H6 L12 12 L6 0 Z"/></svg></button>
-<button id="button_nno" title="Next CSD with no opinion" onclick="set_csd(nno_csd)"{% if nno_csd == 0 %} disabled{% endif %}><svg viewBox="0 0 24 24"><path d="M18 0 L24 12 L18 24 H10 L16 12 L10 0 Z M8 0 L14 12 L8 24 H0 L6 12 L0 0 Z"/></svg></button>
+<button id="button_nno" title="Next CSD with no opinion" onclick="set_csd('nno')"{% if csd == last_csd %} disabled{% endif %}><svg viewBox="0 0 24 24"><path d="M18 0 L24 12 L18 24 H10 L16 12 L10 0 Z M8 0 L14 12 L8 24 H0 L6 12 L0 0 Z"/></svg></button>
 <button id="button_last" title="Last CSD" onclick="set_csd(last_csd)"{% if csd == last_csd %} disabled{% endif %}><svg viewBox="0 0 24 24"><path d="M22 0 V24 H18 V12 L10 24 H2 L10 12 L2 0 H10 L18 12 V0 Z "/></svg></button>
 </div>
 <br><span class="pickrev-span">Revision:</span>

--- a/viewer/web/daily.js
+++ b/viewer/web/daily.js
@@ -59,11 +59,9 @@ function update_data(result) {
 
   // Update the nav button targets
   if ("first_csd" in result) { first_csd = result.first_csd }
-  if ("pno_csd" in result)   { pno_csd = result.pno_csd }
   if ("prev_csd" in result)  { prev_csd = result.prev_csd }
 
   if ("last_csd" in result) { first_csd = result.first_csd }
-  if ("nno_csd" in result)   { nno_csd = result.nno_csd }
   if ("next_csd" in result)  { next_csd = result.next_csd }
 
   draw_ui(csd_changed || rev_changed)
@@ -109,10 +107,10 @@ function draw_ui(view_changed) {
 
   // Enable/disable buttons
   set_disable("button_first", csd == first_csd)
-  set_disable("button_pno", pno_csd == 0)
+  set_disable("button_pno", csd == first_csd)
   set_disable("button_prev", prev_csd == 0)
   set_disable("button_next", next_csd == 0)
-  set_disable("button_nno", nno_csd == 0)
+  set_disable("button_nno", csd == last_csd)
   set_disable("button_last", csd == last_csd)
 
   // Set selector input
@@ -148,18 +146,26 @@ function set_rev(rev_in) {
 
 // Called whenever a new CSD is requested
 function set_csd(csd_in) {
-  // coerce to number
-  var new_csd = +csd_in
+  var new_csd = csd_in;
+  var render_early = 1;
 
-  // Ignore non-numbers
-  if (new_csd != new_csd) {
-    new_csd = csd
-  }
+  // Handle special cases
+  if (csd_in == "pno" || csd_in == "nno") {
+    render_early = 0;
+  } else {
+    // coerce to number
+    new_csd = +csd_in
 
-  // Has anything changed?
-  if (new_csd == csd) {
-    // If not, do nothing
-    return
+    // Ignore non-numbers
+    if (new_csd != new_csd) {
+      new_csd = csd
+    }
+
+    // Has anything changed?
+    if (new_csd == csd) {
+      // If not, do nothing
+      return
+    }
   }
 
   // Create a request for data from the server
@@ -199,8 +205,10 @@ function set_csd(csd_in) {
   xhr.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");
   xhr.send(post_data)
 
-  // Assume the new CSD is correct, and pre-emptively load the new render
-  document.getElementById("frame").src = window.location.pathname + "?render=" + revname(rev) + "_" + csd
+  if (render_early) {
+    // Assume the new CSD is correct, and pre-emptively load the new render
+    document.getElementById("frame").src = window.location.pathname + "?render=" + revname(rev) + "_" + csd
+  }
 
   // Nothing else to do until the XHR returns
 }


### PR DESCRIPTION
I think this fixes issues with the nav buttons.  Test running over here with the production render directory: https://bao.chimenet.ca/daily-test/view

Major points:
* The client now knows nothing about the target of PNO and NNO buttons. Instead, it just sends a request to the server to tell it where to go.
* Navigation as a whole is now revision independent.  Revision will change if navigation to a CSD without the current revision occurs.

Because there's no longer any reason to calculate the next/previous CSD with no opinion (except in cases where the user has clicked one of those buttons), some of the CSD-finding calculation in `csd_data` has been simplified with the no-opinion-finding pushed into a subroutine that's only called when necessary.

This simplifies things, although this update is more disruptive to the code than I would have liked.

I think in a follow-up PR I'll change things again where the client has a notion of it's preferred revision (set by the button the user clicks on), which it can revert to, when possible.  With this change, the server will switch revisions on you if you navigate to a day without the originating revision, which is probably fine, but might be annoying, if you're trying to get to rev 8 days.

(The "prev/next no-opinion" buttons respect the current revision.  It's the others that do not (prev/next, first/last).

Bonus fix: if the client specifies no revision, the default revision is now the latest revision, not the first.