### PR TITLE
fix(viewer): disable the early rendering

### DIFF
--- a/viewer/web/daily.js
+++ b/viewer/web/daily.js
@@ -148,7 +148,12 @@ function set_rev(rev_in) {
 // Called whenever a new CSD is requested
 function set_csd(csd_in) {
   var new_csd = csd_in;
-  var render_early = 1;
+
+  // If you set this to 1 here, then the client will attempt to render the
+  // notebook for the (csd, rev) its trying to load before hearing from the
+  // server, which might give the illusion of lower latency, in certain
+  // situations.
+  var render_early = 0;
 
   // Handle special cases
   if (csd_in == "pno" || csd_in == "nno") {


### PR DESCRIPTION
OK, playing around a bit more, I think the "early rendering" is now more trouble than its worth.  With the "sticky" revisions from #34 now if I start in rev-8 and then end up on a rev-7-only day, there will be a flicker where the client tries to load the missing rev-8 notebook before replacing it with the rev-7 notebook after the server informs it that only rev-7 exists.

For now, I've disabled early rendering by just setting `render_early` to 0 always in the client, rather than deleting the code, meaning it's easy to revert if desired.

I've deployed this change.