### PR TITLE
feat(viewer): Button to toggle UI collapse

### DIFF
--- a/viewer/templates/base.html.j2
+++ b/viewer/templates/base.html.j2
@@ -8,7 +8,8 @@
     {% block headmatter %}{% endblock %}
   </HEAD>
   <BODY>
-    <div class="ui {{ ui_class | d('') }}">{% if flash is defined %}<div id="flash" class="flash flash-{{ flash_type | d('info') }}">{{ flash }}{% else %}<div id="flash" class="flash flash-empty">&nbsp;{% endif %}</div>{% block ui %}BASE UI{% endblock %}</div>
+    <div id="hiddenui"><button onclick="toggle_ui(1)">▼</button></div>
+    <div id="ui" class="ui {{ ui_class | d('') }}"><button style="float: left" onclick="toggle_ui(0)">▲</button>{% if flash is defined %}<div id="flash" class="flash flash-{{ flash_type | d('info') }}">{{ flash }}{% else %}<div id="flash" class="flash flash-empty">&nbsp;{% endif %}</div>{% block ui %}BASE UI{% endblock %}</div>
       <IFRAME class="ui {{ ui_class | d('') }}" id="frame" src="{% block iframesrc %}MISSING{% endblock %}"></IFRAME>
   </BODY>
 </HTML>

--- a/viewer/web/daily.css
+++ b/viewer/web/daily.css
@@ -4,6 +4,16 @@ body {
   margin: 0;
 }
 
+div.hiddenui {
+  position: fixed;
+  margin: 0;
+  padding: 0;
+  top: 0;
+  left: 0;
+  display: none;
+  background: rgba(0,0,0,0);
+}
+
 div.ui {
   height: 300px;
   margin: 0;

--- a/viewer/web/daily.js
+++ b/viewer/web/daily.js
@@ -13,6 +13,26 @@ function revname(rev) {
   return "rev" + srev.slice(-2)
 }
 
+function toggle_ui(show) {
+  // toggle visibility of the UI
+  ui = document.getElementById("ui")
+  noui = document.getElementById("hiddenui")
+  frame = document.getElementById("frame")
+  if (show) {
+    noui.style.display="none";
+    ui.style.display="block";
+    if (frame.classList.contains("ui_2week")) {
+      frame.style["margin-top"]="100px";
+    } else {
+      frame.style["margin-top"]="300px";
+    }
+  } else {
+    ui.style.display="none";
+    noui.style.display="block";
+    frame.style["margin-top"]="0px";
+  }
+}
+
 function set_disable(id, disable) {
   elem = document.getElementById(id)
   if (disable) {


### PR DESCRIPTION
Adds a button to the top left corner of the UI to toggle collapse of the UI, for when you want more screen real estate for the notebook render.  Works in both normal and 2-week view

I've left the test server running here: https://bao.chimenet.ca/daily-test/view