### PR TITLE
Various plot updates for revision 9

### DIFF
--- a/daily_validation.ipynb
+++ b/daily_validation.ipynb
@@ -6,11 +6,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from . import plots\n",
+    "\n",
     "%matplotlib inline\n",
     "%config InlineBackend.figure_format = 'jpg'\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
-    "import helper_funcs as hf\n",
     "from IPython.display import Markdown\n",
     "\n",
     "plt.rcParams.update({'font.size': 22})\n",
@@ -42,7 +43,7 @@
    "source": [
     "Markdown(\n",
     "    f\"# Validation for CSD {LSD} (rev_{rev_id:02d})\"\n",
-    "    f\"## {hf._csd_to_utc(LSD, include_time=True)} UTC - {hf._csd_to_utc(LSD + 1, include_time=True)} UTC\"\n",
+    "    f\"## {plots.csd_to_utc(LSD, include_time=True)} UTC - {plots.csd_to_utc(LSD + 1, include_time=True)} UTC\"\n",
     ")"
    ]
   },
@@ -69,7 +70,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hf.plot_delay_power_spectrum(rev=rev_id, LSD=LSD)"
+    "plots.plot_delay_power_spectrum(rev=rev_id, LSD=LSD)"
    ]
   },
   {
@@ -86,7 +87,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hf.plot_delay_power_spectrum(rev=rev_id, LSD=LSD, hpf=True)"
+    "plots.plot_delay_power_spectrum(rev=rev_id, LSD=LSD, hpf=True)"
    ]
   },
   {
@@ -102,7 +103,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hf.plot_chisq_metric(rev=rev_id, LSD=LSD)"
+    "plots.plot_chisq_metric(rev=rev_id, LSD=LSD)"
    ]
   },
   {
@@ -118,7 +119,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hf.plot_rainfall(rev=rev_id, LSD=LSD)"
+    "plots.plot_rainfall(rev=rev_id, LSD=LSD)"
    ]
   },
   {
@@ -140,7 +141,7 @@
     "scal = [(-5, 20), (-10, 40)]\n",
     "\n",
     "for fi, (vl, vh) in zip(fi_list, scal):\n",
-    "    hf.plot_ringmap(rev=rev_id, LSD=LSD, fi=fi, flag_mask=True, vmin=vl, vmax=vh)"
+    "    plots.plot_ringmap(rev=rev_id, LSD=LSD, fi=fi, flag_mask=True, vmin=vl, vmax=vh)"
    ]
   },
   {
@@ -157,7 +158,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hf.plot_template_subtracted_ringmap(rev=rev_id, LSD=LSD, fi=325, template_rev=3)"
+    "plots.plot_template_subtracted_ringmap(rev=rev_id, LSD=LSD, fi=325, template_rev=3)"
    ]
   },
   {
@@ -183,7 +184,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hf.plot_sensitivity_metric(rev=rev_id, LSD=LSD)"
+    "plots.plot_sensitivity_metric(rev=rev_id, LSD=LSD)"
    ]
   },
   {
@@ -199,7 +200,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hf.plot_vis_power_metric(rev=rev_id, LSD=LSD)"
+    "plots.plot_vis_power_metric(rev=rev_id, LSD=LSD)"
    ]
   },
   {
@@ -215,7 +216,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hf.plot_factorized_mask(rev=rev_id, LSD=LSD)"
+    "plots.plot_factorized_mask(rev=rev_id, LSD=LSD)"
    ]
   },
   {
@@ -236,7 +237,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hf.plot_stability(\n",
+    "plots.plot_stability(\n",
     "    rev_id,\n",
     "    LSD,\n",
     "    norm_sigma=False,\n",
@@ -263,15 +264,8 @@
     "fi_list = [65, 470, 730]\n",
     "\n",
     "for fi in fi_list:\n",
-    "    hf.plot_ringmap(rev=rev_id, LSD=LSD, fi = fi, flag_mask = True)"
+    "    plots.plot_ringmap(rev=rev_id, LSD=LSD, fi = fi, flag_mask = True)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/daily_validation.ipynb
+++ b/daily_validation.ipynb
@@ -12,7 +12,17 @@
     "%config InlineBackend.figure_format = 'jpg'\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
-    "from IPython.display import Markdown\n",
+    "from IPython.display import Markdown, HTML\n",
+    "\n",
+    "HTML(\"\"\"\n",
+    "<style>\n",
+    ".output_png {\n",
+    "    display: table-cell;\n",
+    "    text-align: center;\n",
+    "    vertical-align: middle;\n",
+    "}\n",
+    "</style>\n",
+    "\"\"\")\n",
     "\n",
     "plt.rcParams.update({'font.size': 22})\n",
     "\n",
@@ -51,7 +61,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Delay Spectra and High-Delay Power\n",
+    "# Primary Validation Metrics\n",
     "\n",
     "These are the primary metrics used to judge the quality of a CSD."
    ]
@@ -61,7 +71,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Delay Spectrum "
+    "## Delay Power Spectrum "
    ]
   },
   {
@@ -78,7 +88,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Delay Spectrum with high pass filter"
+    "## High-pass filtered Delay Power Spectrum"
    ]
   },
   {
@@ -94,7 +104,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## High-delay Power Contribution"
+    "## High-delay Chi-Squared"
    ]
   },
   {
@@ -107,10 +117,27 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Accumulated Rainfall "
+    "## System Sensitivity"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plots.plot_sensitivity_metric(rev=rev_id, LSD=LSD)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Accumulated Rainfall "
    ]
   },
   {
@@ -168,23 +195,6 @@
     "# Masking Metrics\n",
     "\n",
     "These are used to judge how well each RFI masking technique is working."
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## System Sensitivity"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plots.plot_sensitivity_metric(rev=rev_id, LSD=LSD)"
    ]
   },
   {

--- a/daily_validation.ipynb
+++ b/daily_validation.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from . import plots\n",
+    "import plots\n",
     "\n",
     "%matplotlib inline\n",
     "%config InlineBackend.figure_format = 'jpg'\n",
@@ -52,8 +52,10 @@
    "outputs": [],
    "source": [
     "Markdown(\n",
-    "    f\"# Validation for CSD {LSD} (rev_{rev_id:02d})\"\n",
-    "    f\"## {plots.csd_to_utc(LSD, include_time=True)} UTC - {plots.csd_to_utc(LSD + 1, include_time=True)} UTC\"\n",
+    "    f\"# Validation for CSD {LSD} (rev_{rev_id:02d})\\n\"\n",
+    "    f\"## {plots.csd_to_utc(LSD, include_time=True)} UTC - {plots.csd_to_utc(LSD + 1, include_time=True)} UTC\\n\"\n",
+    "    f\"## Calibrator: {plots.query_calibrator(LSD)}\\n\"\n",
+    "    \"_Calibrator entry may be inaccurate if gains were manually changed._\"\n",
     ")"
    ]
   },

--- a/daily_validation.ipynb
+++ b/daily_validation.ipynb
@@ -86,23 +86,6 @@
    ]
   },
   {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## High-pass filtered Delay Power Spectrum"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plots.plot_delay_power_spectrum(rev=rev_id, LSD=LSD, hpf=True)"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -139,7 +122,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Source Flux"
+    "## Source Flux Spectra"
    ]
   },
   {
@@ -252,10 +235,29 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Extra Plots\n",
-    "\n",
-    "These are not to be used for validation, just for debugging bad days and for developing them further.\n",
-    "\n",
+    "# Extra Plots"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## High-pass filtered Delay Power Spectrum"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plots.plot_delay_power_spectrum(rev=rev_id, LSD=LSD, hpf=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Point source stability"
    ]
   },

--- a/daily_validation.ipynb
+++ b/daily_validation.ipynb
@@ -137,6 +137,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Source Flux"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plots.plot_point_source_spectra(rev=rev_id, LSD=LSD)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Accumulated Rainfall "
    ]
   },

--- a/daily_validation.ipynb
+++ b/daily_validation.ipynb
@@ -69,7 +69,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hf.plotDS(rev=rev_id, LSD=LSD)"
+    "hf.plot_delay_power_spectrum(rev=rev_id, LSD=LSD)"
    ]
   },
   {
@@ -86,7 +86,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hf.plotDS(rev=rev_id, LSD=LSD, hpf=True)"
+    "hf.plot_delay_power_spectrum(rev=rev_id, LSD=LSD, hpf=True)"
    ]
   },
   {
@@ -102,7 +102,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hf.plotChisq(rev=rev_id, LSD=LSD)"
+    "hf.plot_chisq_metric(rev=rev_id, LSD=LSD)"
    ]
   },
   {
@@ -140,7 +140,7 @@
     "scal = [(-5, 20), (-10, 40)]\n",
     "\n",
     "for fi, (vl, vh) in zip(fi_list, scal):\n",
-    "    hf.plotRingmap(rev=rev_id, LSD=LSD, fi=fi, flag_mask=True, vmin=vl, vmax=vh)"
+    "    hf.plot_ringmap(rev=rev_id, LSD=LSD, fi=fi, flag_mask=True, vmin=vl, vmax=vh)"
    ]
   },
   {
@@ -157,7 +157,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hf.plotRM_tempSub(rev=rev_id, LSD=LSD, fi=325, template_rev=3)"
+    "hf.plot_template_subtracted_ringmap(rev=rev_id, LSD=LSD, fi=325, template_rev=3)"
    ]
   },
   {
@@ -183,7 +183,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hf.plotSens(rev=rev_id, LSD=LSD)"
+    "hf.plot_sensitivity_metric(rev=rev_id, LSD=LSD)"
    ]
   },
   {
@@ -199,7 +199,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hf.plotVisPwr(rev=rev_id, LSD=LSD)"
+    "hf.plot_vis_power_metric(rev=rev_id, LSD=LSD)"
    ]
   },
   {
@@ -215,7 +215,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hf.plotFactMask(rev=rev_id, LSD=LSD)"
+    "hf.plot_factorized_mask(rev=rev_id, LSD=LSD)"
    ]
   },
   {
@@ -263,7 +263,7 @@
     "fi_list = [65, 470, 730]\n",
     "\n",
     "for fi in fi_list:\n",
-    "    hf.plotRingmap(rev=rev_id, LSD=LSD, fi = fi, flag_mask = True)"
+    "    hf.plot_ringmap(rev=rev_id, LSD=LSD, fi = fi, flag_mask = True)"
    ]
   },
   {

--- a/plots/__init__.py
+++ b/plots/__init__.py
@@ -1,0 +1,3 @@
+"""Plotting functions."""
+
+from ._plotfuncs import *  # noqa: F403

--- a/plots/_plotfuncs.py
+++ b/plots/_plotfuncs.py
@@ -1538,3 +1538,156 @@ def infill_gaps(data, x, y, xspan=None, yspan=None):
 
 
 # ========================================================================
+
+
+def plot_delay_power_spectra_and_chisq(
+    rev,
+    csd_start,
+    num_days,
+    reverse=True,
+    hpf=False,
+    clim_ds=[1e-4, 1e0],
+    clim_chisq=[0.9, 1.4],
+    cmap="inferno",
+):
+    """Plot multiple delay spectra and corresponding chisq metric in a given range.
+
+    Parameters
+    ----------
+    rev : int
+        Revision number
+    csd_start : int
+        First csd in the range
+    num_days : int
+        Number of days to plot, starting at `csd_start`
+    reverse : bool, optional
+        If true, display days in decreasing order
+    hpf : bool, optional
+        delay spectra with/without high pass filter (True/False)
+    clim_ds : list, optional
+        min, max values in the delay spectrum colourscale
+    clim_chisq : list, optional
+        min, max values in the chisquared colourscale
+    cmap : colormap, optional (default 'inferno')
+        colourmap to use for all plots
+    """
+
+    if num_days < 1:
+        print("No days requested")
+        return
+
+    # Accumulate the number of days available
+    count = 0
+    csds = list(range(csd_start, csd_start + num_days))
+    if reverse:
+        csds = csds[::-1]
+
+    ds_type_ = "delayspectrum_hpf" if hpf else "delayspectrum"
+
+    plt_shape = (num_days, 2)
+
+    # Make the figure and axes
+    fig, ax = plt.subplots(
+        *plt_shape,
+        figsize=(int(10 * plt_shape[1]), int(10 * plt_shape[0])),
+        layout="constrained",
+    )
+    # If no data is plotted, we probably shouldn't display anything
+    im = None
+    ds_imshow_params = {
+        "origin": "lower",
+        "aspect": "auto",
+        "interpolation": "nearest",
+        "norm": LogNorm(),
+        "clim": clim_ds,
+        "cmap": cmap,
+    }
+    chisq_imshow_params = {
+        "origin": "lower",
+        "aspect": "auto",
+        "interpolation": "nearest",
+        "norm": LogNorm(),
+        "clim": clim_chisq,
+        "cmap": cmap,
+    }
+
+    for ii, csd in enumerate(csds):
+        # First load and plot the power spectrum
+        dspath = _get_rev_path(ds_type_, rev, csd)
+
+        try:
+            DS = containers.DelaySpectrum.from_file(dspath)
+        except FileNotFoundError:
+            # Hide this axis, but don't actually disable it
+            _hide_axis(ax[ii, 0])
+            # grey out this subplot
+            ax[ii, 0].set_facecolor("#686868")
+            ds_found = False
+        else:
+            ds_found = True
+
+        # Now load the chisq
+        cpath = _get_rev_path("chisq", rev, csd)
+
+        try:
+            chisq = containers.TimeStream.from_file(cpath)
+        except FileNotFoundError:
+            # Hide this axis, but don't actually disable it
+            _hide_axis(ax[ii, 1])
+            # grey out this subplot
+            ax[ii, 1].set_facecolor("#686868")
+            chisq_found = False
+        else:
+            chisq_found = True
+
+        if (not chisq_found) and (not ds_found):
+            count += 1
+            continue
+
+        # Plot the power spectrum
+        # Get the axis extent and any masking
+        tau = DS.index_map["delay"] * 1e3
+        baseline_vec = DS.index_map["baseline"]
+        bl_mask = _mask_baselines(baseline_vec, single_mask=True)
+        bl_mask = np.tile(bl_mask, (len(tau), 1))
+
+        extent = [0, baseline_vec.shape[0], tau[0], tau[-1]]
+
+        im = ax[ii, 0].imshow(
+            np.ma.masked_array(DS.spectrum[:].T.real, mask=~bl_mask.T),
+            extent=extent,
+            **ds_imshow_params,
+        )
+        date = csd_to_utc(csd, include_time=True)
+        ax[ii, 0].set_title(f"{csd} ({date})")
+
+        # Plot the chisq. Unfortunately this is just copy-pasted
+        # from the other chisq plotting code. We should really
+        # rework this whole module
+        vis = chisq.vis[:, 0].real
+
+        # Load all input masks
+        rfm = np.zeros(vis.shape, dtype=bool)
+        for name in {"stokesi_mask", "sens_mask", "freq_mask", "chisq_mask"}:
+            rfi_path = _get_rev_path(name, rev, csd)
+            try:
+                file = containers.RFIMask.from_file(rfi_path)
+            except FileNotFoundError:
+                continue
+            rfm |= file.mask[:]
+
+        # Apply the masks and crop
+        vis *= np.where(rfm == 0, 1, np.nan)
+        vis *= np.where(_mask_flags(chisq.time, csd), np.nan, 1)
+
+        # Expand missing times
+        vis, times, _ = infill_gaps(vis, chisq.time, chisq.freq)
+
+        # Select only the times that fall within the actual CSD
+        sel = _select_CSD_bounds(times, csd)
+        vis = vis[:, sel]
+
+        extent = (*_get_extent(times[sel], csd), 400, 800)
+        im = ax[ii, 1].imshow(vis, extent=extent, **chisq_imshow_params)
+
+        ...

--- a/plots/_plotfuncs.py
+++ b/plots/_plotfuncs.py
@@ -32,6 +32,22 @@ eph = ephemeris.skyfield_wrapper.ephemeris
 chime_obs = ephemeris.chime
 sf_obs = chime_obs.skyfield_obs()
 
+
+__all__ = [
+    "csd_to_utc",
+    "plot_delay_power_spectrum",
+    "plot_multiple_delay_power_spectra",
+    "plot_ringmap",
+    "plot_template_subtracted_ringmap",
+    "plot_sensitivity_metric",
+    "plot_chisq_metric",
+    "plot_vis_power_metric",
+    "plot_factorized_mask",
+    "plot_rainfall",
+    "plot_point_source_stability",
+]
+
+
 # ==== Plot color defaults ====
 _BAD_VALUE_COLOR = "#1a1a1a"
 _SOURCES = ["sun", "moon", "CAS_A", "CYG_A", "TAU_A", "VIR_A", "B0329+54"]
@@ -94,7 +110,7 @@ def get_csd(day: int | str = None, num_days: int = 0, lag: int = 0) -> int:
     return int(day)
 
 
-def _csd_to_utc(csd: int | str, include_time: bool = False) -> str:
+def csd_to_utc(csd: int | str, include_time: bool = False) -> str:
     """Convert a CSD to a formatted UTC day."""
     date = ephemeris.csd_to_unix(int(csd))
 
@@ -342,7 +358,7 @@ def plot_multiple_delay_power_spectra(
             extent=extent,
             **imshow_params,
         )
-        date = _csd_to_utc(csd, include_time=True)
+        date = csd_to_utc(csd, include_time=True)
         ax[ax_row, ax_col].set_title(f"{csd} ({date})")
 
     if im is None:

--- a/weekly_validation.ipynb
+++ b/weekly_validation.ipynb
@@ -66,7 +66,7 @@
    },
    "outputs": [],
    "source": [
-    "hf.plotMultipleDS(rev_id, csd_start, num_days, reverse=reverse)"
+    "hf.plot_multiple_delay_power_spectra(rev_id, csd_start, num_days, reverse=reverse)"
    ]
   }
  ],

--- a/weekly_validation.ipynb
+++ b/weekly_validation.ipynb
@@ -7,6 +7,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from . import plots\n",
+    "\n",
     "%matplotlib inline\n",
     "%config InlineBackend.figure_format = 'jpg'\n",
     "\n",
@@ -14,8 +16,7 @@
     "\n",
     "plt.rcParams.update({'font.size': 22})\n",
     "\n",
-    "from IPython.display import Markdown\n",
-    "import helper_funcs as hf"
+    "from IPython.display import Markdown"
    ]
   },
   {
@@ -66,7 +67,7 @@
    },
    "outputs": [],
    "source": [
-    "hf.plot_multiple_delay_power_spectra(rev_id, csd_start, num_days, reverse=reverse)"
+    "plots.plot_multiple_delay_power_spectra(rev_id, csd_start, num_days, reverse=reverse)"
    ]
   }
  ],

--- a/weekly_validation.ipynb
+++ b/weekly_validation.ipynb
@@ -7,16 +7,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from . import plots\n",
+    "from IPython.display import Markdown\n",
+    "\n",
+    "import plots\n",
     "\n",
     "%matplotlib inline\n",
     "%config InlineBackend.figure_format = 'jpg'\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "plt.rcParams.update({'font.size': 22})\n",
-    "\n",
-    "from IPython.display import Markdown"
+    "plt.rcParams.update({'font.size': 22})"
    ]
   },
   {
@@ -31,7 +31,7 @@
    "outputs": [],
    "source": [
     "# pipeline revision to view\n",
-    "rev_id = 7\n",
+    "rev_id = 8\n",
     "\n",
     "# Number of days to show\n",
     "num_days = 14\n",
@@ -45,7 +45,7 @@
     "reverse = True\n",
     "\n",
     "# This sets the CSD \n",
-    "csd_start = hf.get_csd(CSD, num_days, lag)"
+    "csd_start = plots.get_csd(CSD, num_days, lag)"
    ]
   },
   {
@@ -55,7 +55,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Markdown(f\"# Delay Spectra for CSD {csd_start}-{csd_start + num_days - 1} ({num_days} days, rev_{rev_id:02d})\")"
+    "Markdown(f\"# Chisq for CSD {csd_start}-{csd_start + num_days - 1} ({num_days} days, rev_{rev_id:02d})\")"
    ]
   },
   {
@@ -67,7 +67,7 @@
    },
    "outputs": [],
    "source": [
-    "plots.plot_multiple_delay_power_spectra(rev_id, csd_start, num_days, reverse=reverse)"
+    "plots.plot_multiple_chisq(rev_id, csd_start, num_days, reverse=reverse)"
    ]
   }
  ],


### PR DESCRIPTION
# Daily updates
- Include flux spectra of CygA, CasA, TauA, and VirA for each day, with a reference spectrum from `fluxcat`
- Shuffle metric order based on what has been most/least useful
- Center-align plots
- Display calibrator that was used for this day, if known (at the moment, this only works for days beyond sometime in 2020. Earlier days require this info to be fetched from a file on Fir, which is doable but not yet implemented)

# Weekly updates
- Switch to using `chisq` metric in 14-day view

# Other
- Hide all the plotting stuff in a `plots` submodule, with the hope of eventually splitting/cleaning up the plotting functions
- Improve the names of some of the plotting functions