### PR TITLE
fix(viewer): Always print telescope-local time

### DIFF
--- a/viewer/daily_viewer.py
+++ b/viewer/daily_viewer.py
@@ -614,7 +614,7 @@ def csd_data(target, source, rev, user):
         + csd_start.strftime("%Y-%m-%d %H:%M")
         + " -- "
         + csd_end.strftime("%Y-%m-%d %H:%M")
-        + "</a>"
+        + " PT</a>"
     )
 
     return selections


### PR DESCRIPTION
Now that I'm not in BC, I notice that, while the server was always computing telescope-local time, the JS running in the client was using browser-local time, which was only going to be the same for users in the Pacific Time zone.

So now the JS computes the Pacific Time, too.  (Which, of course, is needlessly involved.)

Not yet deployed.